### PR TITLE
feat: configure network binding through provider data instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ Note: Store the service account key securely, it will not be displayed again
 Create a service account kubeconfig for your KubeVirt cluster.
 Store it in `kubeconfig` file.
 
+If you are using `--data-volume-mode=Filesystem` (which is the default), make sure to enable the `ExpandDisks` featuregate in KubeVirt, e.g.:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - ExpandDisks
+```
+
+By default VMs will use the bridge network binding mode.
+In IPv6 environments you might want to use [passt](https://kubevirt.io/user-guide/network/net_binding_plugins/passt/) instead.
+Make sure to set the provider configuration in your MachineClass accordingly.
+
 ### Using Docker
 
 ```bash

--- a/cmd/omni-infra-provider-kubevirt/data/schema.json
+++ b/cmd/omni-infra-provider-kubevirt/data/schema.json
@@ -16,6 +16,10 @@
       "type": "integer",
       "minimum": 5,
       "description": "In GB"
+    },
+    "network_binding": {
+      "enum": ["bridge", "passt"],
+      "default": "bridge"
     }
   },
   "required": [

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -6,8 +6,9 @@ package provider
 
 // Data is the provider custom machine config.
 type Data struct {
-	Architecture string `yaml:"architecture"`
-	Cores        int    `yaml:"cores"`
-	DiskSize     int    `yaml:"disk_size"`
-	Memory       uint64 `yaml:"memory"`
+	Architecture   string `yaml:"architecture"`
+	NetworkBinding string `yaml:"network_binding,omitempty"`
+	Cores          int    `yaml:"cores"`
+	DiskSize       int    `yaml:"disk_size"`
+	Memory         uint64 `yaml:"memory"`
 }

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -217,6 +217,20 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 			vm.Spec.Template.Spec.Domain.Resources.Requests[v1.ResourceMemory] = *resource.NewQuantity(int64(data.Memory)*1024*1024, resource.DecimalSI)
 
+			vm.Spec.Template.Spec.Networks = []kvv1.Network{
+				*kvv1.DefaultPodNetwork(),
+			}
+
+			networkInterface := *kvv1.DefaultBridgeNetworkInterface()
+			if data.NetworkBinding == "passt" {
+				networkInterface = kvv1.Interface{
+					Name: networkInterface.Name,
+					Binding: &kvv1.PluginBinding{
+						Name: "passt",
+					},
+				}
+			}
+
 			vm.Spec.Template.Spec.Domain.Devices = kvv1.Devices{
 				Disks: []kvv1.Disk{
 					{
@@ -228,6 +242,9 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 							},
 						},
 					},
+				},
+				Interfaces: []kvv1.Interface{
+					networkInterface,
 				},
 			}
 


### PR DESCRIPTION
Expose network binding in provider schema to allow configuration of KubeVirt network binding on a per MachineClass-basis.