### PR TITLE
fix: DataVolume too small to contain image

### DIFF
--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -7,7 +7,7 @@ mkdir -p "${TMP}"
 
 # Settings.
 
-TALOS_VERSION=1.9.6
+TALOS_VERSION=1.10.5
 OMNI_VERSION=${OMNI_VERSION:-latest}
 K8S_VERSION="${K8S_VERSION:-1.32.7}"
 

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -116,7 +116,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 						},
 						Resources: v1.VolumeResourceRequirements{
 							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse("1.5Gi"),
+								v1.ResourceStorage: resource.MustParse("3Gi"),
 							},
 						},
 					},


### PR DESCRIPTION
Hi,

At the moment, whenever I try to run a control plane, I end up with an error provided by Kubevirt's CDI:
<img width="1410" height="345" alt="image" src="https://github.com/user-attachments/assets/d5ef9cfb-3a1b-40d6-81b9-c5e72115772c" />
<img width="1410" height="345" alt="image" src="https://github.com/user-attachments/assets/399daa79-b0c3-4ff1-adc9-9338c0b92d94" />

In an attempt to patch this i make this PR