### PR TITLE
Allow specifying image-factory base URL

### DIFF
--- a/cmd/omni-infra-provider-kubevirt/main.go
+++ b/cmd/omni-infra-provider-kubevirt/main.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/siderolabs/omni/client/pkg/client"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/infra"
+	factory "github.com/siderolabs/omni/client/pkg/infra/imagefactory"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -92,7 +94,7 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("data-volume-mode flags should be one of %s", volumeOpts)
 		}
 
-		provisioner := provider.NewProvisioner(k8sClient, cfg.namespace, cfg.dataVolumeMode)
+		provisioner := provider.NewProvisioner(k8sClient, cfg.imageFactoryBaseURL, cfg.namespace, cfg.dataVolumeMode)
 
 		ip, err := infra.NewProvider(meta.ProviderID, provisioner, infra.ProviderConfig{
 			Name:        cfg.providerName,
@@ -114,14 +116,27 @@ var rootCmd = &cobra.Command{
 			clientOptions = append(clientOptions, client.WithServiceAccount(cfg.serviceAccountKey))
 		}
 
-		return ip.Run(cmd.Context(), logger, infra.WithOmniEndpoint(cfg.omniAPIEndpoint), infra.WithClientOptions(
-			clientOptions...,
-		), infra.WithEncodeRequestIDsIntoTokens())
+		factoryClient, err := factory.NewClient(factory.ClientOptions{
+			FactoryEndpoint: cfg.imageFactoryBaseURL,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create factory client: %w", err)
+		}
+
+		return ip.Run(
+			cmd.Context(),
+			logger,
+			infra.WithOmniEndpoint(cfg.omniAPIEndpoint),
+			infra.WithImageFactoryClient(factoryClient),
+			infra.WithClientOptions(clientOptions...),
+			infra.WithEncodeRequestIDsIntoTokens(),
+		)
 	},
 }
 
 var cfg struct {
 	omniAPIEndpoint     string
+	imageFactoryBaseURL string
 	serviceAccountKey   string
 	providerName        string
 	providerDescription string
@@ -145,8 +160,8 @@ func app() error {
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&cfg.omniAPIEndpoint, "omni-api-endpoint", os.Getenv("OMNI_ENDPOINT"),
-		"the endpoint of the Omni API, if not set, defaults to OMNI_ENDPOINT env var.")
+	rootCmd.Flags().StringVar(&cfg.omniAPIEndpoint, "omni-api-endpoint", os.Getenv("OMNI_ENDPOINT"), "the endpoint of the Omni API, if not set, defaults to OMNI_ENDPOINT env var.")
+	rootCmd.Flags().StringVar(&cfg.imageFactoryBaseURL, "image-factory-base-url", constants.ImageFactoryBaseURL, "The base URL of the image factory.")
 	rootCmd.Flags().StringVar(&meta.ProviderID, "id", meta.ProviderID, "the id of the infra provider, it is used to match the resources with the infra provider label.")
 	rootCmd.Flags().StringVar(&cfg.serviceAccountKey, "omni-service-account-key", os.Getenv("OMNI_SERVICE_ACCOUNT_KEY"), "Omni service account key, if not set, defaults to OMNI_SERVICE_ACCOUNT_KEY.")
 	rootCmd.Flags().StringVar(&cfg.providerName, "provider-name", "KubeVirt", "provider name as it appears in Omni")

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/uuid"
 	pointer "github.com/siderolabs/go-pointer"
-	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/infra/provision"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"go.uber.org/zap"
@@ -35,14 +34,16 @@ import (
 // Provisioner implements Talos emulator infra provider.
 type Provisioner struct {
 	k8sClient  client.Client
+	factoryURL string
 	namespace  string
 	volumeMode v1.PersistentVolumeMode
 }
 
 // NewProvisioner creates a new provisioner.
-func NewProvisioner(k8sClient client.Client, namespace, volumeMode string) *Provisioner {
+func NewProvisioner(k8sClient client.Client, factoryURL, namespace, volumeMode string) *Provisioner {
 	return &Provisioner{
 		k8sClient:  k8sClient,
+		factoryURL: factoryURL,
 		namespace:  namespace,
 		volumeMode: v1.PersistentVolumeMode(volumeMode),
 	}
@@ -76,7 +77,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 		provision.NewStep("ensureVolume", func(ctx context.Context, _ *zap.Logger, pctx provision.Context[*resources.Machine]) error {
 			pctx.State.TypedSpec().Value.TalosVersion = pctx.GetTalosVersion()
 
-			url, err := url.Parse(constants.ImageFactoryBaseURL)
+			url, err := url.Parse(p.factoryURL)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR allows setting a different URL than the default one (https://factory.talos.dev) for the provisioner. This way, air-gapped (or restricted) environments can use the provider by hosting their own image factory.