### PR TITLE
feat: add vm_labels support to provider data

### DIFF
--- a/internal/pkg/provider/data/data.go
+++ b/internal/pkg/provider/data/data.go
@@ -17,11 +17,12 @@ var Schema []byte
 
 // Data and schema.json should be in sync.
 type Data struct {
-	StorageClassName string `yaml:"storage_class_name"`
-	NetworkBinding   string `yaml:"network_binding,omitempty"`
-	Architecture     string `yaml:"architecture"`
-	Tolerations      string `yaml:"tolerations"`
-	Cores            int    `yaml:"cores"`
-	Memory           uint64 `yaml:"memory"`
-	DiskSize         int    `yaml:"disk_size"`
+	VMLabels         map[string]string `yaml:"vm_labels,omitempty"`
+	StorageClassName string            `yaml:"storage_class_name"`
+	NetworkBinding   string            `yaml:"network_binding,omitempty"`
+	Architecture     string            `yaml:"architecture"`
+	Tolerations      string            `yaml:"tolerations"`
+	Cores            int               `yaml:"cores"`
+	Memory           uint64            `yaml:"memory"`
+	DiskSize         int               `yaml:"disk_size"`
 }

--- a/internal/pkg/provider/data/schema.json
+++ b/internal/pkg/provider/data/schema.json
@@ -27,7 +27,17 @@
     },
     "tolerations": {
       "type": "string",
-      "description": "Tolerations for the VirtualMachine encoded as a JSON array"
+      "description": "Tolerations for the VirtualMachine encoded as a JSON array",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "vm_labels": {
+      "type": "object",
+      "description": "Custom labels to apply to the VirtualMachine resource",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "required": [

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"time"
 
@@ -315,6 +316,15 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 			vm.Spec.DataVolumeTemplates = []kvv1.DataVolumeTemplateSpec{
 				volumeTemplate,
+			}
+
+			// Apply user-provided labels to the launcher pod
+			if len(data.VMLabels) > 0 {
+				if vm.Spec.Template.ObjectMeta.Labels == nil {
+					vm.Spec.Template.ObjectMeta.Labels = map[string]string{}
+				}
+
+				maps.Copy(vm.Spec.Template.ObjectMeta.Labels, data.VMLabels)
 			}
 
 			if vm.Name == "" {


### PR DESCRIPTION
This allows passing custom labels to KubeVirt VirtualMachine resources through the provider_data configuration. Labels are applied to both new and existing VMs during reconciliation.

This is required for cloud-provider-kubevirt loadbalancer service provider to work with Omni-managed KubeVirt clusters, which need specific labels on VMs for proper functionality.

The vm_labels field accepts a map[string]string and works with cluster templates. Note: The Omni UI currently doesn't render map[string]string fields, but the functionality works correctly.